### PR TITLE
Migrate projects to supported .NET versions

### DIFF
--- a/samples/MakeItEasyCQRS.Examples.HowToUse/MakeItEasyCQRS.Examples.HowToUse.csproj
+++ b/samples/MakeItEasyCQRS.Examples.HowToUse/MakeItEasyCQRS.Examples.HowToUse.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MakeItEasyCQRS/MakeItEasyCQRS.csproj
+++ b/src/MakeItEasyCQRS/MakeItEasyCQRS.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageId>MakeItEasyCQRS</PackageId>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Authors>João Greco</Authors>
     <Company>grecojoao</Company>
     <PackageDescription>Easily use the CQRS design pattern!</PackageDescription>
     <RepositoryUrl>https://github.com/grecojoao/MakeItEasyCQRS</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.0.2</AssemblyVersion>
-    <FileVersion>1.0.0.2</FileVersion>
+    <AssemblyVersion>1.0.0.3</AssemblyVersion>
+    <FileVersion>1.0.0.3</FileVersion>
     <Description />
-    <PackageReleaseNotes>Added new interfaces for command and generic handlers.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added .NET 8 and .NET 10 support.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DomainNotifications" Version="1.0.2" />


### PR DESCRIPTION
## Summary
- Migrates the library to target `net8.0` and `net10.0`
- Migrates the sample project to `net10.0`
- Updates package version to `1.0.3`

## Validation
- `dotnet build MakeItEasyCQRS.sln -c Release`
- `dotnet list MakeItEasyCQRS.sln package --vulnerable --include-transitive`